### PR TITLE
bump tomcat version 8.5.58 to 8.5.69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <httpcore.version>4.4.11</httpcore.version>
         <xerces.version>2.12.0</xerces.version>
         <cglib.version>3.2.7</cglib.version>
-        <tomcat.version>8.5.58</tomcat.version>
+        <tomcat.version>8.5.69</tomcat.version>
         <red5-io.version>1.2.2</red5-io.version> 
         <cors-filter.version>2.5</cors-filter.version>
 		<periscope-api.version>1.3.0</periscope-api.version>


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/3438
Updates tomcat version from 8.5.58 to 8.5.69.